### PR TITLE
Add support for SSL database connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is a simple guide to show how to deploy the latest version of WordPress usi
 
 1. Go to [stacksmith.bitnami.com](https://stacksmith.bitnami.com).
 2. Create a new application and select the `Generic application with DB (MySQL)` stack template.
-3. Select the targets you are interested on (AWS, Kubernetes,...).
+3. Select the targets you are interested on (AWS, Azure, Kubernetes,...).
 4. Select `Git repository` for the application scripts and paste the URL of this repo. Use `master` as the `Repository Reference`.
 5. Click the <kbd>Create</kbd> button. This will start building an image for the latest available version of WordPress for each of your selected targets.
 6. Wait for the latest version of WordPress to be built, and deploy it in your favorite target platform.
@@ -52,7 +52,7 @@ This script takes care of starting the application.
 You can add extra plugins by specifing them in the `boot.sh` script:
 
 ```bash
-readonly plugin_names="akismet all-in-one-wp-migration"
+readonly plugin_names="akismet all-in-one-wp-migration secure-db-connection"
 ```
 
 You can also download the zip files in <https://wordpress.org/plugins/> and add them as `Application files` in the Stacksmith UI. Then, Stacksmith will repackage your application with those plugins.
@@ -102,7 +102,7 @@ Unpack the downloaded tarball and edit the following files:
   +  ## If defined, storageClassName: <storageClass>
   +  ## If set to "-", storageClassName: "", which disables dynamic provisioning
   +  ## If undefined (the default) or set to null, no storageClassName spec is
-  +  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  +  ##   set, choosing the default provisioner. (gp2 on AWS, standard on
   +  ##   GKE, AWS & OpenStack)
   +  ##
   +  # storageClass: "-"

--- a/stacksmith/user-scripts/boot.sh
+++ b/stacksmith/user-scripts/boot.sh
@@ -7,6 +7,8 @@ getSSLCA() {
         echo "/opt/stacksmith/stacksmith-scripts/extra/rds-combined-ca-bundle.pem"
     elif [ -f "/opt/azure-db.crt.pem" ]; then
 	echo "/opt/azure-db.crt.pem"
+    elif [ -f "/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt" ]; then
+	echo "/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt"
     else
 	echo ""
     fi

--- a/stacksmith/user-scripts/boot.sh
+++ b/stacksmith/user-scripts/boot.sh
@@ -2,8 +2,22 @@
 
 set -euo pipefail
 
+getSSLCA() {
+    if [ -f "/opt/stacksmith/stacksmith-scripts/extra/rds-combined-ca-bundle.pem" ]; then
+        echo "/opt/stacksmith/stacksmith-scripts/extra/rds-combined-ca-bundle.pem"
+    elif [ -f "/opt/azure-db.crt.pem" ]; then
+	echo "/opt/azure-db.crt.pem"
+    else
+	echo ""
+    fi
+}
+
 waitForDatabase() {
-    while ! wp --path=$installdir db check --quiet; do
+    local command=("wp" "--path=$installdir" "db" "check" "--quiet")
+    if [ -n "$(getSSLCA)" ]; then
+        command=("${command[@]}" "--ssl-ca=$(getSSLCA)")
+    fi
+    while ! "${command[@]}"; do
         echo "==> Waiting for database to become available..."
         sleep 2
     done
@@ -26,10 +40,14 @@ configureWordPress() {
         --dbuser=$DATABASE_USER \
         --dbpass=$DATABASE_PASSWORD \
         --skip-check \
-        --extra-php <<'EOF'
+        --extra-php <<EOF
 /** Detect current hostname automatically. */
-define('WP_SITEURL', 'http://' . $_SERVER['HTTP_HOST'] . '/');
-define('WP_HOME', 'http://' . $_SERVER['HTTP_HOST'] . '/');
+define('WP_SITEURL', 'http://' . \$_SERVER['HTTP_HOST'] . '/');
+define('WP_HOME', 'http://' . \$_SERVER['HTTP_HOST'] . '/');
+
+/** Force SSL for database connections */
+define('MYSQL_CLIENT_FLAGS', MYSQLI_CLIENT_SSL);
+define('MYSQL_SSL_CA', '$(getSSLCA)');
 EOF
 }
 
@@ -44,7 +62,7 @@ installWordPress() {
 }
 
 installPlugins() {
-    readonly plugin_names="akismet all-in-one-wp-migration"
+    readonly plugin_names="akismet all-in-one-wp-migration secure-db-connection"
 
     echo "==> Installing plugins by name..."
     wp --path=$installdir plugin install $plugin_names --activate

--- a/stacksmith/user-scripts/build.sh
+++ b/stacksmith/user-scripts/build.sh
@@ -21,6 +21,12 @@ downloadWordPress() {
     wp --path=$installdir core download
 }
 
+downloadSSLCertificates() {
+    echo "==> Downloading SSL certificates..."
+    # ref: https://docs.microsoft.com/en-us/azure/mysql/howto-configure-ssl
+    curl -Lo '/opt/azure-db.crt.pem' https://www.digicert.com/CACerts/BaltimoreCyberTrustRoot.crt.pem
+}
+
 prepareDataToPersist() {
     chown -R apache "${installdir}/wp-content"
     mv "${installdir}/wp-content" /opt/
@@ -33,6 +39,7 @@ main() {
     installDependencies
     installWordPressCLI
     downloadWordPress
+    downloadSSLCertificates
     prepareDataToPersist
 }
 


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

## Description of the change

This PR adds the [Secure DB Connection](https://wordpress.org/plugins/secure-db-connection/) plugin to the WP example for **Stacksmith** and configure the corresponding SSL certificates to ensure that connections with the database are encrypted.

## Benefits

- Improves the security in the WP example.
- It allows using this example app on cloud providers that enables Database SSL Enforcement. 